### PR TITLE
Fix `process` is not defined

### DIFF
--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -140,4 +140,4 @@ export const getScrollAncestor = node => {
 }
 
 export const floatEqual = (a, b) => Math.abs(a - b) < 0.001;
-export const isProd = process && process.env && process.env.NODE_ENV === 'production';
+export const isProd = process.env.NODE_ENV === 'production';


### PR DESCRIPTION
Fixes #114

Webpack 5 doesn't polyfill the node global `process`. It only replaces strict references of `process.env.NODE_ENV` to a string.