### PR TITLE
Allow Promise handler for MenuItem onClick

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -212,7 +212,7 @@ export interface MenuItemProps extends Omit<BaseProps<MenuItemModifiers>, 'onCli
     type?: MenuItemTypeProp;
     checked?: boolean;
     disabled?: boolean;
-    onClick?: EventHandler<ClickEvent, boolean | void>;
+    onClick?: EventHandler<ClickEvent, boolean | void | Promise<void>>;
     children?: RenderProp<MenuItemModifiers>;
 }
 


### PR DESCRIPTION
Current Typescript definition for MenuItem.onClick does not allow handlers that return Promise. Without changing current behaviour for the handler, my correction should allow to use handlers that return Promise with no value.