### PR TITLE
Fix SSR errors when rendering menu via portal

### DIFF
--- a/dist/es/components/ControlledMenu.js
+++ b/dist/es/components/ControlledMenu.js
@@ -153,7 +153,7 @@ var ControlledMenu = /*#__PURE__*/forwardRef(function ControlledMenu(_ref, exter
     })
   }));
 
-  if (portal) {
+  if (portal && typeof document !== 'undefined') {
     return /*#__PURE__*/createPortal(menuList, document.body);
   } else {
     return menuList;

--- a/dist/es/components/SubMenu.js
+++ b/dist/es/components/SubMenu.js
@@ -206,7 +206,8 @@ var SubMenu = /*#__PURE__*/withHovering('SubMenu', function SubMenu(_ref) {
       isDisabled: isDisabled
     }));
 
-    return isPortal ? /*#__PURE__*/createPortal(menuList, rootMenuRef.current) : menuList;
+    var container = rootMenuRef.current;
+    return isPortal && container ? /*#__PURE__*/createPortal(menuList, container) : menuList;
   };
 
   return /*#__PURE__*/jsxs("li", {

--- a/dist/index.js
+++ b/dist/index.js
@@ -1571,7 +1571,7 @@ var ControlledMenu = /*#__PURE__*/react.forwardRef(function ControlledMenu(_ref,
     })
   }));
 
-  if (portal) {
+  if (portal && typeof document !== 'undefined') {
     return /*#__PURE__*/reactDom.createPortal(menuList, document.body);
   } else {
     return menuList;
@@ -1869,7 +1869,8 @@ var SubMenu = /*#__PURE__*/withHovering('SubMenu', function SubMenu(_ref) {
       isDisabled: isDisabled
     }));
 
-    return isPortal ? /*#__PURE__*/reactDom.createPortal(menuList, rootMenuRef.current) : menuList;
+    var container = rootMenuRef.current;
+    return isPortal && container ? /*#__PURE__*/reactDom.createPortal(menuList, container) : menuList;
   };
 
   return /*#__PURE__*/jsxRuntime.jsxs("li", {

--- a/src/components/ControlledMenu.js
+++ b/src/components/ControlledMenu.js
@@ -178,7 +178,7 @@ export const ControlledMenu = forwardRef(function ControlledMenu(
     </div>
   );
 
-  if (portal) {
+  if (portal && typeof document !== 'undefined') {
     return createPortal(menuList, document.body);
   } else {
     return menuList;

--- a/src/components/SubMenu.js
+++ b/src/components/SubMenu.js
@@ -216,7 +216,8 @@ export const SubMenu = withHovering(
           isDisabled={isDisabled}
         />
       );
-      return isPortal ? createPortal(menuList, rootMenuRef.current) : menuList;
+      const container = rootMenuRef.current;
+      return isPortal && container ? createPortal(menuList, container) : menuList;
     };
 
     return (


### PR DESCRIPTION
Resolve server rendering errors when:
- `portal` prop is true on a menu.
- Parent menu of a submenu has overflow.