### PR TITLE
Fix menu detached from anchor when rendered via portal

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -25,16 +25,17 @@
     "plugin:react-hooks/recommended"
   ],
   "rules": {
-    "jest/expect-expect": [
-      "error",
-      {
-        "assertFunctionNames": ["expect", "utils.expect*"]
-      }
-    ],
+    "no-console": ["error", { "allow": ["warn", "error"] }],
     "no-unused-vars": [
       "error",
       {
         "argsIgnorePattern": "^_\\d?$"
+      }
+    ],
+    "jest/expect-expect": [
+      "error",
+      {
+        "assertFunctionNames": ["expect", "utils.expect*"]
       }
     ],
     "react/prop-types": 0,

--- a/dist/es/components/ControlledMenu.js
+++ b/dist/es/components/ControlledMenu.js
@@ -5,7 +5,7 @@ import { oneOf, exact, number, object, bool, oneOfType, string, func } from 'pro
 import { MenuList } from './MenuList.js';
 import { jsx } from 'react/jsx-runtime';
 import { useBEM } from '../hooks/useBEM.js';
-import { CloseReason, menuContainerClass, SettingsContext, ItemSettingsContext, EventHandlersContext, MenuStateMap, Keys } from '../utils/constants.js';
+import { SettingsContext, ItemSettingsContext, EventHandlersContext, MenuStateMap, Keys, CloseReason, menuContainerClass } from '../utils/constants.js';
 import { rootMenuPropTypes } from '../utils/propTypes.js';
 import { safeCall, getTransition, attachHandlerProps, values, isMenuOpen } from '../utils/utils.js';
 
@@ -36,8 +36,7 @@ var ControlledMenu = /*#__PURE__*/forwardRef(function ControlledMenu(_ref, exter
       restProps = _objectWithoutPropertiesLoose(_ref, _excluded);
 
   var containerRef = useRef(null);
-  var scrollingRef = useRef(null);
-  var anchorScrollingRef = useRef(null);
+  var scrollNodesRef = useRef({});
   var anchorRef = restProps.anchorRef,
       state = restProps.state;
   var settings = useMemo(function () {
@@ -50,8 +49,7 @@ var ControlledMenu = /*#__PURE__*/forwardRef(function ControlledMenu(_ref, exter
       boundingBoxPadding: boundingBoxPadding,
       rootMenuRef: containerRef,
       rootAnchorRef: anchorRef,
-      scrollingRef: scrollingRef,
-      anchorScrollingRef: anchorScrollingRef,
+      scrollNodesRef: scrollNodesRef,
       reposition: reposition,
       viewScroll: viewScroll
     };

--- a/dist/es/components/FocusableItem.js
+++ b/dist/es/components/FocusableItem.js
@@ -1,4 +1,4 @@
-import { objectWithoutPropertiesLoose as _objectWithoutPropertiesLoose, extends as _extends } from '../_virtual/_rollupPluginBabelHelpers.js';
+import { extends as _extends, objectWithoutPropertiesLoose as _objectWithoutPropertiesLoose } from '../_virtual/_rollupPluginBabelHelpers.js';
 import { useRef, useContext, useMemo } from 'react';
 import { bool, func } from 'prop-types';
 import { jsx } from 'react/jsx-runtime';
@@ -6,9 +6,9 @@ import { withHovering } from '../utils/withHovering.js';
 import { useItemState } from '../hooks/useItemState.js';
 import { useCombinedRef } from '../hooks/useCombinedRef.js';
 import { useBEM } from '../hooks/useBEM.js';
+import { stylePropTypes } from '../utils/propTypes.js';
 import { EventHandlersContext, menuClass, menuItemClass } from '../utils/constants.js';
 import { safeCall, attachHandlerProps, commonProps } from '../utils/utils.js';
-import { stylePropTypes } from '../utils/propTypes.js';
 
 var _excluded = ["className", "disabled", "children", "isHovering", "itemRef", "externalRef"];
 var FocusableItem = /*#__PURE__*/withHovering('FocusableItem', function FocusableItem(_ref) {

--- a/dist/es/components/MenuButton.js
+++ b/dist/es/components/MenuButton.js
@@ -1,11 +1,11 @@
-import { objectWithoutPropertiesLoose as _objectWithoutPropertiesLoose, extends as _extends } from '../_virtual/_rollupPluginBabelHelpers.js';
+import { extends as _extends, objectWithoutPropertiesLoose as _objectWithoutPropertiesLoose } from '../_virtual/_rollupPluginBabelHelpers.js';
 import { forwardRef, useMemo } from 'react';
 import { bool } from 'prop-types';
 import { jsx } from 'react/jsx-runtime';
 import { defineName } from '../utils/utils.js';
 import { useBEM } from '../hooks/useBEM.js';
-import { menuButtonClass } from '../utils/constants.js';
 import { stylePropTypes } from '../utils/propTypes.js';
+import { menuButtonClass } from '../utils/constants.js';
 
 var _excluded = ["className", "isOpen", "disabled", "children"];
 var MenuButton = /*#__PURE__*/defineName('MenuButton', /*#__PURE__*/forwardRef(function MenuButton(_ref, ref) {

--- a/dist/es/components/MenuItem.js
+++ b/dist/es/components/MenuItem.js
@@ -1,4 +1,4 @@
-import { objectWithoutPropertiesLoose as _objectWithoutPropertiesLoose, extends as _extends } from '../_virtual/_rollupPluginBabelHelpers.js';
+import { extends as _extends, objectWithoutPropertiesLoose as _objectWithoutPropertiesLoose } from '../_virtual/_rollupPluginBabelHelpers.js';
 import { useContext, useMemo } from 'react';
 import { any, string, oneOf, bool, oneOfType, node, func } from 'prop-types';
 import { jsx } from 'react/jsx-runtime';
@@ -7,8 +7,8 @@ import { useItemState } from '../hooks/useItemState.js';
 import { EventHandlersContext, RadioGroupContext, menuClass, menuItemClass, Keys } from '../utils/constants.js';
 import { useCombinedRef } from '../hooks/useCombinedRef.js';
 import { useBEM } from '../hooks/useBEM.js';
-import { attachHandlerProps, commonProps, safeCall } from '../utils/utils.js';
 import { stylePropTypes } from '../utils/propTypes.js';
+import { attachHandlerProps, commonProps, safeCall } from '../utils/utils.js';
 
 var _excluded = ["className", "value", "href", "type", "checked", "disabled", "children", "onClick", "isHovering", "itemRef", "externalRef"],
     _excluded2 = ["setHover"];

--- a/dist/es/components/SubMenu.js
+++ b/dist/es/components/SubMenu.js
@@ -1,18 +1,18 @@
-import { objectWithoutPropertiesLoose as _objectWithoutPropertiesLoose, extends as _extends } from '../_virtual/_rollupPluginBabelHelpers.js';
+import { extends as _extends, objectWithoutPropertiesLoose as _objectWithoutPropertiesLoose } from '../_virtual/_rollupPluginBabelHelpers.js';
 import { useContext, useRef, useEffect, useImperativeHandle, useMemo } from 'react';
 import { createPortal } from 'react-dom';
 import { bool, oneOf, oneOfType, node, func, shape } from 'prop-types';
 import { MenuList } from './MenuList.js';
 import { jsxs, jsx } from 'react/jsx-runtime';
 import { withHovering } from '../utils/withHovering.js';
+import { menuPropTypes, uncontrolledMenuPropTypes, stylePropTypes } from '../utils/propTypes.js';
 import { useMenuStateAndFocus } from '../hooks/useMenuStateAndFocus.js';
 import { useItemEffect } from '../hooks/useItemEffect.js';
 import { useMenuChange } from '../hooks/useMenuChange.js';
 import { useBEM } from '../hooks/useBEM.js';
 import { SettingsContext, ItemSettingsContext, MenuListContext, MenuListItemContext, HoverActionTypes, menuClass, subMenuClass, menuItemClass, Keys, FocusPositions } from '../utils/constants.js';
 import { useCombinedRef } from '../hooks/useCombinedRef.js';
-import { menuPropTypes, uncontrolledMenuPropTypes, stylePropTypes } from '../utils/propTypes.js';
-import { isMenuOpen, attachHandlerProps, safeCall, commonProps, batchedUpdates } from '../utils/utils.js';
+import { attachHandlerProps, commonProps, safeCall, isMenuOpen, batchedUpdates } from '../utils/utils.js';
 
 var _excluded = ["aria-label", "className", "disabled", "direction", "label", "openTrigger", "onMenuChange", "isHovering", "instanceRef", "itemRef", "captureFocus", "repositionFlag", "itemProps"],
     _excluded2 = ["ref", "className"];

--- a/dist/es/positionUtils/getPositionHelpers.js
+++ b/dist/es/positionUtils/getPositionHelpers.js
@@ -1,18 +1,14 @@
 import { parsePadding } from '../utils/utils.js';
 
-var getPositionHelpers = function getPositionHelpers(_ref) {
-  var menuRef = _ref.menuRef,
-      containerRef = _ref.containerRef,
-      scrollingRef = _ref.scrollingRef,
-      boundingBoxPadding = _ref.boundingBoxPadding;
+var getPositionHelpers = function getPositionHelpers(containerRef, menuRef, menuScroll, boundingBoxPadding) {
   var menuRect = menuRef.current.getBoundingClientRect();
   var containerRect = containerRef.current.getBoundingClientRect();
-  var boundingRect = scrollingRef.current === window ? {
+  var boundingRect = menuScroll === window ? {
     left: 0,
     top: 0,
     right: document.documentElement.clientWidth,
     bottom: window.innerHeight
-  } : scrollingRef.current.getBoundingClientRect();
+  } : menuScroll.getBoundingClientRect();
   var padding = parsePadding(boundingBoxPadding);
 
   var getLeftOverflow = function getLeftOverflow(x) {

--- a/dist/es/utils/utils.js
+++ b/dist/es/utils/utils.js
@@ -79,17 +79,17 @@ var parsePadding = function parsePadding(paddingStr) {
   };
 };
 var getScrollAncestor = function getScrollAncestor(node) {
-  while (node && node !== document.body) {
+  while (node) {
+    node = node.parentNode;
+    if (!node || node === document.body) return;
+
     var _getComputedStyle = getComputedStyle(node),
         overflow = _getComputedStyle.overflow,
         overflowX = _getComputedStyle.overflowX,
         overflowY = _getComputedStyle.overflowY;
 
     if (/auto|scroll|overlay|hidden/.test(overflow + overflowY + overflowX)) return node;
-    node = node.parentNode;
   }
-
-  return window;
 };
 function commonProps(isDisabled, isHovering) {
   return {

--- a/dist/index.js
+++ b/dist/index.js
@@ -193,17 +193,17 @@ var parsePadding = function parsePadding(paddingStr) {
   };
 };
 var getScrollAncestor = function getScrollAncestor(node) {
-  while (node && node !== document.body) {
+  while (node) {
+    node = node.parentNode;
+    if (!node || node === document.body) return;
+
     var _getComputedStyle = getComputedStyle(node),
         overflow = _getComputedStyle.overflow,
         overflowX = _getComputedStyle.overflowX,
         overflowY = _getComputedStyle.overflowY;
 
     if (/auto|scroll|overlay|hidden/.test(overflow + overflowY + overflowX)) return node;
-    node = node.parentNode;
   }
-
-  return window;
 };
 function commonProps(isDisabled, isHovering) {
   return {
@@ -590,19 +590,15 @@ process.env.NODE_ENV !== "production" ? MenuButton.propTypes = /*#__PURE__*/_ext
   disabled: propTypes.bool
 }) : void 0;
 
-var getPositionHelpers = function getPositionHelpers(_ref) {
-  var menuRef = _ref.menuRef,
-      containerRef = _ref.containerRef,
-      scrollingRef = _ref.scrollingRef,
-      boundingBoxPadding = _ref.boundingBoxPadding;
+var getPositionHelpers = function getPositionHelpers(containerRef, menuRef, menuScroll, boundingBoxPadding) {
   var menuRect = menuRef.current.getBoundingClientRect();
   var containerRect = containerRef.current.getBoundingClientRect();
-  var boundingRect = scrollingRef.current === window ? {
+  var boundingRect = menuScroll === window ? {
     left: 0,
     top: 0,
     right: document.documentElement.clientWidth,
     bottom: window.innerHeight
-  } : scrollingRef.current.getBoundingClientRect();
+  } : menuScroll.getBoundingClientRect();
   var padding = parsePadding(boundingBoxPadding);
 
   var getLeftOverflow = function getLeftOverflow(x) {
@@ -1040,8 +1036,7 @@ var MenuList = function MenuList(_ref) {
       boundingBoxPadding = _useContext.boundingBoxPadding,
       rootMenuRef = _useContext.rootMenuRef,
       rootAnchorRef = _useContext.rootAnchorRef,
-      scrollingRef = _useContext.scrollingRef,
-      anchorScrollingRef = _useContext.anchorScrollingRef,
+      scrollNodesRef = _useContext.scrollNodesRef,
       reposition = _useContext.reposition,
       viewScroll = _useContext.viewScroll;
 
@@ -1063,6 +1058,7 @@ var MenuList = function MenuList(_ref) {
   var isOpen = isMenuOpen(state);
   var openTransition = getTransition(transition, 'open');
   var closeTransition = getTransition(transition, 'close');
+  var scrollNodes = scrollNodesRef.current;
 
   var handleKeyDown = function handleKeyDown(e) {
     var handled = false;
@@ -1110,7 +1106,7 @@ var MenuList = function MenuList(_ref) {
     safeCall(endTransition);
   };
 
-  var handlePosition = react.useCallback(function () {
+  var handlePosition = react.useCallback(function (noOverflowCheck) {
     if (!containerRef.current) {
       if (process.env.NODE_ENV !== 'production') {
         console.error('[React-Menu] Menu cannot be positioned properly as container ref is null. If you need to initialise `state` prop to "open" for ControlledMenu, please see this solution: https://codesandbox.io/s/initial-open-sp10wn');
@@ -1119,16 +1115,11 @@ var MenuList = function MenuList(_ref) {
       return;
     }
 
-    if (!scrollingRef.current) {
-      scrollingRef.current = boundingBoxRef ? boundingBoxRef.current : getScrollAncestor(rootMenuRef.current);
+    if (!scrollNodes.menu) {
+      scrollNodes.menu = (boundingBoxRef ? boundingBoxRef.current : getScrollAncestor(rootMenuRef.current)) || window;
     }
 
-    var positionHelpers = getPositionHelpers({
-      menuRef: menuRef,
-      containerRef: containerRef,
-      scrollingRef: scrollingRef,
-      boundingBoxPadding: boundingBoxPadding
-    });
+    var positionHelpers = getPositionHelpers(containerRef, menuRef, scrollNodes.menu, boundingBoxPadding);
     var menuRect = positionHelpers.menuRect;
     var results = {
       computedDirection: 'bottom'
@@ -1161,7 +1152,7 @@ var MenuList = function MenuList(_ref) {
         computedDirection = _results.computedDirection;
     var menuHeight = menuRect.height;
 
-    if (overflow !== 'visible') {
+    if (!noOverflowCheck && overflow !== 'visible') {
       var getTopOverflow = positionHelpers.getTopOverflow,
           getBottomOverflow = positionHelpers.getBottomOverflow;
 
@@ -1207,7 +1198,7 @@ var MenuList = function MenuList(_ref) {
       width: menuRect.width,
       height: menuHeight
     };
-  }, [arrow, align, boundingBoxPadding, direction, offsetX, offsetY, position, overflow, anchorPoint, anchorRef, containerRef, boundingBoxRef, rootMenuRef, scrollingRef]);
+  }, [arrow, align, boundingBoxPadding, direction, offsetX, offsetY, position, overflow, anchorPoint, anchorRef, containerRef, boundingBoxRef, rootMenuRef, scrollNodes]);
   useIsomorphicLayoutEffect(function () {
     if (isOpen) {
       handlePosition();
@@ -1224,23 +1215,29 @@ var MenuList = function MenuList(_ref) {
     return updateItems;
   }, [updateItems]);
   react.useEffect(function () {
-    if (!isOpen) return;
+    var menuScroll = scrollNodes.menu;
+    if (!isOpen || !menuScroll) return;
+    menuScroll = menuScroll.addEventListener ? menuScroll : window;
 
-    if (!anchorScrollingRef.current && rootAnchorRef && rootAnchorRef.current.tagName) {
-      anchorScrollingRef.current = getScrollAncestor(rootAnchorRef.current);
+    if (!scrollNodes.anchors) {
+      scrollNodes.anchors = [];
+      var anchorScroll = getScrollAncestor(rootAnchorRef && rootAnchorRef.current);
+
+      while (anchorScroll && anchorScroll !== menuScroll) {
+        scrollNodes.anchors.push(anchorScroll);
+        anchorScroll = getScrollAncestor(anchorScroll);
+      }
     }
 
-    var scrollCurrent = scrollingRef.current;
-    var menuScroll = scrollCurrent && scrollCurrent.addEventListener ? scrollCurrent : window;
-    var anchorScroll = anchorScrollingRef.current || menuScroll;
     var scroll = viewScroll;
-    if (anchorScroll !== menuScroll && scroll === 'initial') scroll = 'auto';
+    if (scrollNodes.anchors.length && scroll === 'initial') scroll = 'auto';
     if (scroll === 'initial') return;
-    if (scroll === 'auto' && overflow !== 'visible') return;
 
     var handleScroll = function handleScroll() {
       if (scroll === 'auto') {
-        batchedUpdates(handlePosition);
+        batchedUpdates(function () {
+          return handlePosition(true);
+        });
       } else {
         safeCall(onClose, {
           reason: CloseReason.SCROLL
@@ -1248,7 +1245,7 @@ var MenuList = function MenuList(_ref) {
       }
     };
 
-    var scrollObservers = anchorScroll !== menuScroll && viewScroll !== 'initial' ? [anchorScroll, menuScroll] : [anchorScroll];
+    var scrollObservers = scrollNodes.anchors.concat(viewScroll !== 'initial' ? menuScroll : []);
     scrollObservers.forEach(function (o) {
       return o.addEventListener('scroll', handleScroll);
     });
@@ -1257,7 +1254,7 @@ var MenuList = function MenuList(_ref) {
         return o.removeEventListener('scroll', handleScroll);
       });
     };
-  }, [rootAnchorRef, anchorScrollingRef, scrollingRef, isOpen, overflow, onClose, viewScroll, handlePosition]);
+  }, [rootAnchorRef, scrollNodes, isOpen, onClose, viewScroll, handlePosition]);
   var hasOverflow = !!overflowData && overflowData.overflowAmt > 0;
   react.useEffect(function () {
     if (hasOverflow || !isOpen || !parentScrollingRef) return;
@@ -1456,8 +1453,7 @@ var ControlledMenu = /*#__PURE__*/react.forwardRef(function ControlledMenu(_ref,
       restProps = _objectWithoutPropertiesLoose(_ref, _excluded$8);
 
   var containerRef = react.useRef(null);
-  var scrollingRef = react.useRef(null);
-  var anchorScrollingRef = react.useRef(null);
+  var scrollNodesRef = react.useRef({});
   var anchorRef = restProps.anchorRef,
       state = restProps.state;
   var settings = react.useMemo(function () {
@@ -1470,8 +1466,7 @@ var ControlledMenu = /*#__PURE__*/react.forwardRef(function ControlledMenu(_ref,
       boundingBoxPadding: boundingBoxPadding,
       rootMenuRef: containerRef,
       rootAnchorRef: anchorRef,
-      scrollingRef: scrollingRef,
-      anchorScrollingRef: anchorScrollingRef,
+      scrollNodesRef: scrollNodesRef,
       reposition: reposition,
       viewScroll: viewScroll
     };

--- a/example/src/data/documentation.js
+++ b/example/src/data/documentation.js
@@ -501,12 +501,7 @@ const rootMenuProps = [
           </li>
           <li>
             <code>'auto'</code> Menu will reposition itself based on the value of{' '}
-            <code>position</code> prop when window is scrolling.{' '}
-            <p>
-              Note: for the best user experience, if the <code>overflow</code> prop is set to a
-              value other than 'visible', an 'auto' <code>viewScroll</code> will behave as
-              'initial'.
-            </p>
+            <code>position</code> prop when window is scrolling.
           </li>
           <li>
             <code>'close'</code> menu will be closed when window is scrolled.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@szhsin/react-menu",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "React component for building accessible menu, dropdown, submenu, context menu and more.",
   "author": "Zheng Song",
   "license": "MIT",

--- a/src/__tests__/ControlledMenu.test.js
+++ b/src/__tests__/ControlledMenu.test.js
@@ -75,6 +75,13 @@ test('ControlledMenu with an anchor element; ref is forwarded', async () => {
   utils.expectMenuToBeInTheDocument(false);
 });
 
+test('ControlledMenu warns when open by default', () => {
+  const spy = jest.spyOn(console, 'error').mockImplementation();
+  render(getMenu({ state: 'open' }));
+  expect(spy).toHaveBeenCalledWith(expect.stringContaining('container ref is null'));
+  spy.mockRestore();
+});
+
 test('ControlledMenu as context menu', () => {
   const anchorPoint = { x: 0, y: 0 };
   const props = { anchorPoint };

--- a/src/components/ControlledMenu.js
+++ b/src/components/ControlledMenu.js
@@ -44,8 +44,7 @@ export const ControlledMenu = forwardRef(function ControlledMenu(
   externalRef
 ) {
   const containerRef = useRef(null);
-  const scrollingRef = useRef(null);
-  const anchorScrollingRef = useRef(null);
+  const scrollNodesRef = useRef({});
   const { anchorRef, state } = restProps;
 
   const settings = useMemo(
@@ -58,8 +57,7 @@ export const ControlledMenu = forwardRef(function ControlledMenu(
       boundingBoxPadding,
       rootMenuRef: containerRef,
       rootAnchorRef: anchorRef,
-      scrollingRef,
-      anchorScrollingRef,
+      scrollNodesRef,
       reposition,
       viewScroll
     }),

--- a/src/positionUtils/getPositionHelpers.js
+++ b/src/positionUtils/getPositionHelpers.js
@@ -1,17 +1,17 @@
 import { parsePadding } from '../utils';
 
-export const getPositionHelpers = ({ menuRef, containerRef, scrollingRef, boundingBoxPadding }) => {
+export const getPositionHelpers = (containerRef, menuRef, menuScroll, boundingBoxPadding) => {
   const menuRect = menuRef.current.getBoundingClientRect();
   const containerRect = containerRef.current.getBoundingClientRect();
   const boundingRect =
-    scrollingRef.current === window
+    menuScroll === window
       ? {
           left: 0,
           top: 0,
           right: document.documentElement.clientWidth,
           bottom: window.innerHeight
         }
-      : scrollingRef.current.getBoundingClientRect();
+      : menuScroll.getBoundingClientRect();
   const padding = parsePadding(boundingBoxPadding);
 
   // For left and top, overflows are negative value.

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -51,12 +51,12 @@ export const parsePadding = (paddingStr) => {
 
 // Adapted from https://github.com/popperjs/popper-core/tree/v2.9.1/src/dom-utils
 export const getScrollAncestor = (node) => {
-  while (node && node !== document.body) {
+  while (node) {
+    node = node.parentNode;
+    if (!node || node === document.body) return;
     const { overflow, overflowX, overflowY } = getComputedStyle(node);
     if (/auto|scroll|overlay|hidden/.test(overflow + overflowY + overflowX)) return node;
-    node = node.parentNode;
   }
-  return window;
 };
 
 export function commonProps(isDisabled, isHovering) {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -268,10 +268,6 @@ interface RootMenuProps extends BaseMenuProps, MenuStateOptions {
    * - 'initial' The window scroll event is ignored and has no effect on menu.
    * - 'auto' Menu will reposition itself based on the value of `position` prop when window is scrolling.
    * - 'close' menu will be closed when window is scrolled.
-   *
-   * *Note: for the best user experience, if the `overflow` prop is set to a value
-   * other than 'visible', an 'auto' `viewScroll` will behave as 'initial'*.
-   *
    * @default 'initial'
    */
   viewScroll?: MenuViewScroll;


### PR DESCRIPTION
The PR fixed menu detaching from anchor when rendered via portal if:
- Menu has `overflow` prop that is not 'visible'
- Multiple ancestor elements have css `overflow` property other than 'visible'
