### PR TITLE
Add anchors management to useMenuState hook

### DIFF
--- a/src/hooks/useMenuState.js
+++ b/src/hooks/useMenuState.js
@@ -1,3 +1,4 @@
+import { useCallback, useRef, useState } from 'react';
 import { useTransition } from 'react-transition-state';
 import { MenuStateMap, getTransition } from '../utils';
 
@@ -7,6 +8,9 @@ export const useMenuState = ({
   transition,
   transitionTimeout = 500
 } = {}) => {
+  const [anchorPoint, setAnchorPoint] = useState();
+  const anchorRef = useRef(null);
+
   const [state, toggleMenu, endTransition] = useTransition({
     mountOnEnter: !initialMounted,
     unmountOnExit: unmountOnClose,
@@ -15,5 +19,26 @@ export const useMenuState = ({
     exit: getTransition(transition, 'close')
   });
 
-  return [{ state: MenuStateMap[state], endTransition }, toggleMenu];
+  const setAnchor = useCallback((value) => {
+    if (value === null) {
+      anchorRef.current = null;
+      setAnchorPoint(undefined);
+      return;
+    }
+
+    if (value instanceof Element) {
+      anchorRef.current = value;
+      setAnchorPoint(undefined);
+      return;
+    }
+
+    setAnchorPoint(value);
+    anchorRef.current = null;
+  }, []);
+
+  return [
+    { state: MenuStateMap[state], endTransition, anchorPoint, anchorRef },
+    toggleMenu,
+    setAnchor
+  ];
 };

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -669,6 +669,14 @@ export function useMenuState(options?: MenuStateOptions): [
      * Stop transition animation. This function value should be forwarded to `ControlledMenu`.
      */
     endTransition: () => void;
+    /**
+     * anchorRef set with the setAnchor function. This function value should be forwarded to `ControlledMenu`.
+     */
+    anchorRef?: Element;
+    /**
+     * anchorPoint set with the setAnchor function. This function value should be forwarded to `ControlledMenu`.
+     */
+    anchorPoint?: { x: number; y: number };
   },
 
   /**
@@ -677,7 +685,15 @@ export function useMenuState(options?: MenuStateOptions): [
    * - If no parameter is supplied, this function will toggle state between open and close phases.
    * - You can set a boolean parameter to explicitly switch into one of the two phases.
    */
-  (open?: boolean) => void
+  (open?: boolean) => void,
+  /**
+   * Set the menu anchor.
+   *
+   * - If a ref is supplied, this function will set anchorRef
+   * - If a XY point is supplied, this function will set anchorPoint
+   * - If null is supplied, both anchorRef and anchorPoint will be changed to null
+   */
+  (anchor?: Element | { x: number; y: number } | null) => void
 ];
 
 export {};


### PR DESCRIPTION
Hi @szhsin,

This is a PR for this issue: https://github.com/szhsin/react-menu/issues/701

**Important**: This is a possible solution. I didn't test it for edge cases but I'm sure that you have sharper eyes than me.

The unit tests are passing but I think we need an extra check when we are using setAnchor(null). In this case, a specific error should be triggered to inform the user that the anchorRef and anchorPoint are null when he toggles the menu.

![image](https://user-images.githubusercontent.com/22646067/198953226-8b7e2fc2-ab2f-4cec-b6b4-9df24be37031.png)

Of course please modify and adapt this idea as you wish if you like it. Thank you and have a nice day!