### PR TITLE
docs: reusing dropdown/context menu

### DIFF
--- a/example/src/data/codeExamples.js
+++ b/example/src/data/codeExamples.js
@@ -983,6 +983,19 @@ export const contextMenu = {
     </>
   ),
 
+  note: (
+    <p>
+      <strong>TIP</strong>: sometimes you may want to reuse one menu for both dropdown and context
+      menu. In this case, you can provide <code>ControlledMenu</code> with both the{' '}
+      <code>anchorRef</code> and <code>anchorPoint</code> props and dynamically switch between them,
+      please see{' '}
+      <ExternalLink href="https://codesandbox.io/s/usecontrolledmenu-9u7tol">
+        a CodeSandbox example
+      </ExternalLink>
+      .
+    </p>
+  ),
+
   source: `const [menuProps, toggleMenu] = useMenuState();
 const [anchorPoint, setAnchorPoint] = useState({ x: 0, y: 0 });
 

--- a/example/src/utils/index.js
+++ b/example/src/utils/index.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useLayoutEffect } from 'react';
 
 export const version = '3.2.1';
-export const build = '114';
+export const build = '115';
 export const DomInfoContext = React.createContext({});
 export const SettingContext = React.createContext({ theme: 'dark' });
 export const TocContext = React.createContext({}); // Table of contents


### PR DESCRIPTION
Example implementation of reusing one menu for both dropdown and context menu. 