### PR TITLE
feat: menu container

### DIFF
--- a/dist/es/components/ControlledMenu.js
+++ b/dist/es/components/ControlledMenu.js
@@ -4,12 +4,11 @@ import { createPortal } from 'react-dom';
 import { oneOf, exact, number, object, bool, oneOfType, string, func } from 'prop-types';
 import { MenuList } from './MenuList.js';
 import { jsx } from 'react/jsx-runtime';
-import { useBEM } from '../hooks/useBEM.js';
-import { SettingsContext, ItemSettingsContext, EventHandlersContext, Keys, CloseReason, MenuStateMap, menuContainerClass } from '../utils/constants.js';
+import { SettingsContext, ItemSettingsContext, EventHandlersContext, MenuStateMap, Keys, CloseReason } from '../utils/constants.js';
 import { rootMenuPropTypes } from '../utils/propTypes.js';
-import { safeCall, getTransition, mergeProps, values, isMenuOpen } from '../utils/utils.js';
+import { safeCall, values } from '../utils/utils.js';
 
-var _excluded = ["aria-label", "className", "containerProps", "initialMounted", "unmountOnClose", "transition", "transitionTimeout", "boundingBoxRef", "boundingBoxPadding", "reposition", "submenuOpenDelay", "submenuCloseDelay", "skipOpen", "viewScroll", "portal", "theming", "onItemClick", "onClose"];
+var _excluded = ["aria-label", "className", "containerProps", "initialMounted", "unmountOnClose", "transition", "transitionTimeout", "boundingBoxRef", "boundingBoxPadding", "reposition", "submenuOpenDelay", "submenuCloseDelay", "skipOpen", "viewScroll", "portal", "theming", "onItemClick"];
 var ControlledMenu = /*#__PURE__*/forwardRef(function ControlledMenu(_ref, externalRef) {
   var ariaLabel = _ref['aria-label'],
     className = _ref.className,
@@ -32,12 +31,12 @@ var ControlledMenu = /*#__PURE__*/forwardRef(function ControlledMenu(_ref, exter
     portal = _ref.portal,
     theming = _ref.theming,
     onItemClick = _ref.onItemClick,
-    onClose = _ref.onClose,
     restProps = _objectWithoutPropertiesLoose(_ref, _excluded);
   var containerRef = useRef(null);
   var scrollNodesRef = useRef({});
   var anchorRef = restProps.anchorRef,
-    state = restProps.state;
+    state = restProps.state,
+    onClose = restProps.onClose;
   var settings = useMemo(function () {
     return {
       initialMounted: initialMounted,
@@ -83,67 +82,30 @@ var ControlledMenu = /*#__PURE__*/forwardRef(function ControlledMenu(_ref, exter
       }
     };
   }, [onItemClick, onClose]);
-  var onKeyDown = function onKeyDown(_ref2) {
-    var key = _ref2.key;
-    switch (key) {
-      case Keys.ESC:
-        safeCall(onClose, {
-          key: key,
-          reason: CloseReason.CANCEL
-        });
-        break;
-    }
-  };
-  var onBlur = function onBlur(e) {
-    if (isMenuOpen(state) && !e.currentTarget.contains(e.relatedTarget || document.activeElement)) {
-      safeCall(onClose, {
-        reason: CloseReason.BLUR
-      });
-
-      if (skipOpen) {
-        skipOpen.current = true;
-        setTimeout(function () {
-          return skipOpen.current = false;
-        }, 300);
-      }
-    }
-  };
-  var itemTransition = getTransition(transition, 'item');
-  var modifiers = useMemo(function () {
-    return {
-      theme: theming,
-      itemTransition: itemTransition
-    };
-  }, [theming, itemTransition]);
-  var menuList = /*#__PURE__*/jsx("div", _extends({}, mergeProps({
-    onKeyDown: onKeyDown,
-    onBlur: onBlur
-  }, containerProps), {
-    className: useBEM({
-      block: menuContainerClass,
-      modifiers: modifiers,
-      className: className
-    }),
-    style: _extends({}, containerProps == null ? void 0 : containerProps.style, {
-      position: 'relative'
-    }),
-    ref: containerRef,
-    children: state && /*#__PURE__*/jsx(SettingsContext.Provider, {
-      value: settings,
-      children: /*#__PURE__*/jsx(ItemSettingsContext.Provider, {
-        value: itemSettings,
-        children: /*#__PURE__*/jsx(EventHandlersContext.Provider, {
-          value: eventHandlers,
-          children: /*#__PURE__*/jsx(MenuList, _extends({}, restProps, {
-            ariaLabel: ariaLabel || 'Menu',
-            externalRef: externalRef,
+  if (!state) return null;
+  var menuList = /*#__PURE__*/jsx(SettingsContext.Provider, {
+    value: settings,
+    children: /*#__PURE__*/jsx(ItemSettingsContext.Provider, {
+      value: itemSettings,
+      children: /*#__PURE__*/jsx(EventHandlersContext.Provider, {
+        value: eventHandlers,
+        children: /*#__PURE__*/jsx(MenuList, _extends({}, restProps, {
+          ariaLabel: ariaLabel || 'Menu',
+          externalRef: externalRef,
+          containerRef: containerRef,
+          containerProps: {
+            className: className,
             containerRef: containerRef,
+            containerProps: containerProps,
+            skipOpen: skipOpen,
+            theming: theming,
+            transition: transition,
             onClose: onClose
-          }))
-        })
+          }
+        }))
       })
     })
-  }));
+  });
   if (portal === true && typeof document !== 'undefined') {
     return /*#__PURE__*/createPortal(menuList, document.body);
   } else if (portal) {

--- a/dist/es/components/Menu.js
+++ b/dist/es/components/Menu.js
@@ -7,10 +7,10 @@ import { useMenuStateAndFocus } from '../hooks/useMenuStateAndFocus.js';
 import { useCombinedRef } from '../hooks/useCombinedRef.js';
 import { isMenuOpen, safeCall, mergeProps, getName } from '../utils/utils.js';
 import { useMenuChange } from '../hooks/useMenuChange.js';
-import { uncontrolledMenuPropTypes, rootMenuPropTypes } from '../utils/propTypes.js';
+import { rootMenuPropTypes, uncontrolledMenuPropTypes } from '../utils/propTypes.js';
 import { FocusPositions, Keys } from '../utils/constants.js';
 
-var _excluded = ["aria-label", "captureFocus", "menuButton", "instanceRef", "onMenuChange"];
+var _excluded = ["aria-label", "captureFocus", "initialOpen", "menuButton", "instanceRef", "onMenuChange"];
 var Menu = /*#__PURE__*/forwardRef(function Menu(_ref, externalRef) {
   var ariaLabel = _ref['aria-label'],
     menuButton = _ref.menuButton,

--- a/dist/es/components/MenuContainer.js
+++ b/dist/es/components/MenuContainer.js
@@ -1,0 +1,66 @@
+import { extends as _extends } from '../_virtual/_rollupPluginBabelHelpers.js';
+import { useMemo } from 'react';
+import { jsx } from 'react/jsx-runtime';
+import { mergeProps, getTransition, safeCall } from '../utils/utils.js';
+import { useBEM } from '../hooks/useBEM.js';
+import { menuContainerClass, Keys, CloseReason } from '../utils/constants.js';
+
+var MenuContainer = function MenuContainer(_ref) {
+  var className = _ref.className,
+    containerRef = _ref.containerRef,
+    containerProps = _ref.containerProps,
+    children = _ref.children,
+    isOpen = _ref.isOpen,
+    skipOpen = _ref.skipOpen,
+    theming = _ref.theming,
+    transition = _ref.transition,
+    onClose = _ref.onClose;
+  var itemTransition = getTransition(transition, 'item');
+  var onKeyDown = function onKeyDown(_ref2) {
+    var key = _ref2.key;
+    switch (key) {
+      case Keys.ESC:
+        safeCall(onClose, {
+          key: key,
+          reason: CloseReason.CANCEL
+        });
+        break;
+    }
+  };
+  var onBlur = function onBlur(e) {
+    if (isOpen && !e.currentTarget.contains(e.relatedTarget || document.activeElement)) {
+      safeCall(onClose, {
+        reason: CloseReason.BLUR
+      });
+
+      if (skipOpen) {
+        skipOpen.current = true;
+        setTimeout(function () {
+          return skipOpen.current = false;
+        }, 300);
+      }
+    }
+  };
+  return /*#__PURE__*/jsx("div", _extends({}, mergeProps({
+    onKeyDown: onKeyDown,
+    onBlur: onBlur
+  }, containerProps), {
+    className: useBEM({
+      block: menuContainerClass,
+      modifiers: useMemo(function () {
+        return {
+          theme: theming,
+          itemTransition: itemTransition
+        };
+      }, [theming, itemTransition]),
+      className: className
+    }),
+    style: _extends({
+      position: 'absolute'
+    }, containerProps == null ? void 0 : containerProps.style),
+    ref: containerRef,
+    children: children
+  }));
+};
+
+export { MenuContainer };

--- a/dist/es/components/MenuList.js
+++ b/dist/es/components/MenuList.js
@@ -1,6 +1,7 @@
 import { objectWithoutPropertiesLoose as _objectWithoutPropertiesLoose, extends as _extends } from '../_virtual/_rollupPluginBabelHelpers.js';
 import { useState, useReducer, useContext, useRef, useCallback, useEffect, useMemo } from 'react';
 import { flushSync } from 'react-dom';
+import { MenuContainer } from './MenuContainer.js';
 import { jsxs, jsx } from 'react/jsx-runtime';
 import { SettingsContext, MenuListContext, HoverActionTypes, MenuListItemContext, HoverItemContext, Keys, menuClass, CloseReason, FocusPositions, menuArrowClass } from '../utils/constants.js';
 import { useItems } from '../hooks/useItems.js';
@@ -11,7 +12,7 @@ import { useLayoutEffect as useIsomorphicLayoutEffect } from '../hooks/useIsomor
 import { useBEM } from '../hooks/useBEM.js';
 import { useCombinedRef } from '../hooks/useCombinedRef.js';
 
-var _excluded = ["ariaLabel", "menuClassName", "menuStyle", "arrowClassName", "arrowStyle", "anchorPoint", "anchorRef", "containerRef", "externalRef", "parentScrollingRef", "arrow", "align", "direction", "position", "overflow", "setDownOverflow", "repositionFlag", "captureFocus", "state", "endTransition", "isDisabled", "menuItemFocus", "offsetX", "offsetY", "children", "onClose"];
+var _excluded = ["ariaLabel", "menuClassName", "menuStyle", "arrowClassName", "arrowStyle", "anchorPoint", "anchorRef", "containerRef", "containerProps", "externalRef", "parentScrollingRef", "arrow", "align", "direction", "position", "overflow", "setDownOverflow", "repositionFlag", "captureFocus", "state", "endTransition", "isDisabled", "menuItemFocus", "offsetX", "offsetY", "children", "onClose"];
 var MenuList = function MenuList(_ref) {
   var ariaLabel = _ref.ariaLabel,
     menuClassName = _ref.menuClassName,
@@ -21,6 +22,7 @@ var MenuList = function MenuList(_ref) {
     anchorPoint = _ref.anchorPoint,
     anchorRef = _ref.anchorRef,
     containerRef = _ref.containerRef,
+    containerProps = _ref.containerProps,
     externalRef = _ref.externalRef,
     parentScrollingRef = _ref.parentScrollingRef,
     arrow = _ref.arrow,
@@ -131,13 +133,8 @@ var MenuList = function MenuList(_ref) {
     safeCall(endTransition);
   };
   var handlePosition = useCallback(function (noOverflowCheck) {
-    if (!containerRef.current) {
-      if (process.env.NODE_ENV !== 'production') {
-        console.error('[React-Menu] Menu cannot be positioned properly as container ref is null. If you need to initialise `state` prop to "open" for ControlledMenu, please see this solution: https://codesandbox.io/s/initial-open-sp10wn');
-      }
-      return;
-    }
-    var anchorRect = anchorRef ? anchorRef.current.getBoundingClientRect() : anchorPoint ? {
+    var _anchorRef$current;
+    var anchorRect = anchorRef ? (_anchorRef$current = anchorRef.current) == null ? void 0 : _anchorRef$current.getBoundingClientRect() : anchorPoint ? {
       left: anchorPoint.x,
       right: anchorPoint.x,
       top: anchorPoint.y,
@@ -147,7 +144,7 @@ var MenuList = function MenuList(_ref) {
     } : null;
     if (!anchorRect) {
       if (process.env.NODE_ENV !== 'production') {
-        console.warn('[React-Menu] Menu might not be positioned properly as one of the anchorRef and anchorPoint prop should be provided.');
+        console.warn('[React-Menu] Menu might not be positioned properly as one of the anchorRef or anchorPoint prop should be provided. If `anchorRef` is provided, the anchor must be mounted before menu is open.');
       }
       return;
     }
@@ -386,7 +383,7 @@ var MenuList = function MenuList(_ref) {
     modifiers: arrowModifiers,
     className: arrowClassName
   });
-  return /*#__PURE__*/jsxs("ul", _extends({
+  var menu = /*#__PURE__*/jsxs("ul", _extends({
     role: "menu",
     "aria-label": ariaLabel
   }, mergeProps({
@@ -433,6 +430,10 @@ var MenuList = function MenuList(_ref) {
       })
     })]
   }));
+  return containerProps ? /*#__PURE__*/jsx(MenuContainer, _extends({}, containerProps, {
+    isOpen: isOpen,
+    children: menu
+  })) : menu;
 };
 
 export { MenuList };

--- a/dist/es/hooks/useMenuState.js
+++ b/dist/es/hooks/useMenuState.js
@@ -4,12 +4,14 @@ import { MenuStateMap } from '../utils/constants.js';
 
 var useMenuState = function useMenuState(_temp) {
   var _ref = _temp === void 0 ? {} : _temp,
+    initialOpen = _ref.initialOpen,
     initialMounted = _ref.initialMounted,
     unmountOnClose = _ref.unmountOnClose,
     transition = _ref.transition,
     _ref$transitionTimeou = _ref.transitionTimeout,
     transitionTimeout = _ref$transitionTimeou === void 0 ? 500 : _ref$transitionTimeou;
   var _useTransition = useTransition({
+      initialEntered: initialOpen,
       mountOnEnter: !initialMounted,
       unmountOnExit: unmountOnClose,
       timeout: transitionTimeout,

--- a/dist/es/utils/propTypes.js
+++ b/dist/es/utils/propTypes.js
@@ -1,5 +1,5 @@
 import { extends as _extends } from '../_virtual/_rollupPluginBabelHelpers.js';
-import { object, bool, oneOfType, exact, number, string, oneOf, func } from 'prop-types';
+import { oneOfType, string, func, object, bool, number, oneOf, exact } from 'prop-types';
 
 var stylePropTypes = function stylePropTypes(name) {
   var _ref;

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -20,7 +20,7 @@
     },
     "..": {
       "name": "@szhsin/react-menu",
-      "version": "3.2.1",
+      "version": "3.3.0",
       "license": "MIT",
       "dependencies": {
         "prop-types": "^15.7.2",
@@ -34,7 +34,7 @@
         "@rollup/plugin-node-resolve": "^15.0.1",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
-        "@types/jest": "^29.2.2",
+        "@types/jest": "^29.2.3",
         "@types/react": "^18.0.25",
         "babel-plugin-pure-annotations": "^0.1.2",
         "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
@@ -51,9 +51,9 @@
         "prettier": "^2.7.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "rollup": "^3.2.5",
+        "rollup": "^3.3.0",
         "sass": "^1.56.1",
-        "typescript": "^4.8.4"
+        "typescript": "^4.9.3"
       },
       "peerDependencies": {
         "react": ">=16.14.0",
@@ -3386,7 +3386,7 @@
         "@rollup/plugin-node-resolve": "^15.0.1",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
-        "@types/jest": "^29.2.2",
+        "@types/jest": "^29.2.3",
         "@types/react": "^18.0.25",
         "babel-plugin-pure-annotations": "^0.1.2",
         "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
@@ -3405,9 +3405,9 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-transition-state": "^1.1.5",
-        "rollup": "^3.2.5",
+        "rollup": "^3.3.0",
         "sass": "^1.56.1",
-        "typescript": "^4.8.4"
+        "typescript": "^4.9.3"
       },
       "dependencies": {
         "react": {

--- a/example/src/components/Usage.js
+++ b/example/src/components/Usage.js
@@ -623,7 +623,7 @@ function BoundingBoxExample() {
 
   useEffect(() => {
     toggleMenu(true);
-  }, [toggleMenu, /* effect dep */ portal]);
+  }, [toggleMenu]);
 
   const tooltipProps = {
     state,
@@ -642,10 +642,7 @@ function BoundingBoxExample() {
         <input
           type="checkbox"
           checked={portal}
-          onChange={(e) => {
-            toggleMenu(false);
-            setPortal(e.target.checked);
-          }}
+          onChange={(e) => setPortal(e.currentTarget.checked)}
         />
         Render via portal
       </label>

--- a/example/src/data/codeExamples.js
+++ b/example/src/data/codeExamples.js
@@ -834,27 +834,37 @@ export const boundingBox = {
 
   desc: (
     <p>
-      Normally menu positions itself within its nearest ancestor element which has CSS{' '}
-      <code>overflow</code> set to a value other than 'visible', or the browser viewport when such
-      an element is not present. You can use the <code>portal</code> prop to make menu visually
-      “break out” of its scrollable container. Also, you can specify a container in the page as the
-      bounding box for a menu using the <code>boundingBoxRef</code> prop. Menu will try to position
-      itself within that container.
+      By default, menu positions itself within its nearest ancestor element which a CSS{' '}
+      <code>overflow</code> value other than <code>visible</code>, or the browser viewport when such
+      an element is not present. Alternalively, you can use the <code>portal</code> prop to make
+      menu visually “break out” of its scrollable container. Also, you can specify a container in
+      the page as the bounding box for a menu using the <code>boundingBoxRef</code> prop. Menu will
+      try to position itself within that container.
     </p>
   ),
 
   note: (
-    <p>
-      You could render menu into a specified DOM node instead of <code>document.body</code> using
-      the <code>portal</code> prop, please see{' '}
-      <ExternalLink href="https://codesandbox.io/s/react-menu-portal-target-boyxv9">
-        a CodeSandbox example
-      </ExternalLink>
-      .
-    </p>
+    <>
+      <p>
+        <strong>NOTE</strong>: when there is an ancestor element which has a CSS{' '}
+        <code>overflow</code> value other than <code>visible</code> above menu, please ensure at
+        least one element between that overflow element and menu has a CSS <code>position</code>{' '}
+        value other than <code>static</code>. For example, you could add{' '}
+        <code>position: relative</code> to the ancestor element which has{' '}
+        <code>overflow: auto</code>.
+      </p>
+      <p>
+        <strong>TIP</strong>: you could render menu into a specified DOM node instead of{' '}
+        <code>document.body</code> using the <code>portal</code> prop, please see{' '}
+        <ExternalLink href="https://codesandbox.io/s/react-menu-portal-target-boyxv9">
+          a CodeSandbox example
+        </ExternalLink>
+        .
+      </p>
+    </>
   ),
 
-  source: `const ref = useRef(null);
+  source: `const boundingBoxRef = useRef(null);
 const leftAnchor = useRef(null);
 const rightAnchor = useRef(null);
 const [{ state }, toggleMenu] = useMenuState();
@@ -881,7 +891,7 @@ const tooltipProps = {
   Render via portal
 </label>
 
-<div ref={ref}>
+<div ref={boundingBoxRef} style={{ overflow: 'auto', position: 'relative' }}>
     <div ref={leftAnchor} />
     <ControlledMenu {...tooltipProps} portal={portal}
         anchorRef={leftAnchor} direction="top">
@@ -890,7 +900,7 @@ const tooltipProps = {
 
     <div ref={rightAnchor} />
     {/* explicitly set bounding box with the boundingBoxRef prop */}
-    <ControlledMenu {...tooltipProps} boundingBoxRef={ref}
+    <ControlledMenu {...tooltipProps} boundingBoxRef={boundingBoxRef}
         anchorRef={rightAnchor} direction="right">
         I'm a tooltip built with React-Menu
     </ControlledMenu>

--- a/example/src/data/documentation.js
+++ b/example/src/data/documentation.js
@@ -1268,6 +1268,7 @@ const menuStateHook = {
       </p>
       <pre>
         <code className="hljs">{`function useMenuState(options?: {
+    initialOpen?: boolean;
     initialMounted?: boolean;
     unmountOnClose?: boolean;
     transition?: boolean | {

--- a/example/src/styles/_example.scss
+++ b/example/src/styles/_example.scss
@@ -169,6 +169,7 @@
 
     .szh-menu-button {
       white-space: nowrap;
+      margin: 0 0.5rem;
     }
 
     .szh-menu {
@@ -186,6 +187,7 @@
   }
 
   .scrollview {
+    position: relative;
     height: 20rem;
     overflow: auto;
     margin-top: 0.75rem;

--- a/example/src/utils/index.js
+++ b/example/src/utils/index.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useLayoutEffect } from 'react';
 
-export const version = '3.2.1';
-export const build = '116';
+export const version = '3.3.0';
+export const build = '117';
 export const DomInfoContext = React.createContext({});
 export const SettingContext = React.createContext({ theme: 'dark' });
 export const TocContext = React.createContext({}); // Table of contents

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@szhsin/react-menu",
-  "version": "3.2.1",
+  "version": "3.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@szhsin/react-menu",
-      "version": "3.2.1",
+      "version": "3.3.0",
       "license": "MIT",
       "dependencies": {
         "prop-types": "^15.7.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@szhsin/react-menu",
-  "version": "3.2.1",
+  "version": "3.3.0",
   "description": "React component for building accessible menu, dropdown, submenu, context menu and more.",
   "author": "Zheng Song",
   "license": "MIT",

--- a/src/__tests__/ControlledMenu.test.js
+++ b/src/__tests__/ControlledMenu.test.js
@@ -75,15 +75,16 @@ test('ControlledMenu with an anchor element; ref is forwarded', async () => {
   utils.expectMenuToBeInTheDocument(false);
 });
 
-test('ControlledMenu warns when open by default', () => {
-  const errorSpy = jest.spyOn(console, 'error').mockImplementation();
-  const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
-  render(getMenu({ state: 'open' }));
-  expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('container ref is null'));
-  expect(warnSpy).toHaveBeenCalled();
-  errorSpy.mockRestore();
-  warnSpy.mockRestore();
-});
+test.each([undefined, {}])(
+  'ControlledMenu warns when open by default without anchor',
+  (anchorRef) => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+    render(getMenu({ state: 'open', anchorRef }));
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('anchorRef or anchorPoint'));
+    warnSpy.mockRestore();
+    utils.expectMenuToBeOpen(true);
+  }
+);
 
 test('ControlledMenu as context menu', () => {
   const anchorPoint = { x: 0, y: 0 };

--- a/src/__tests__/Menu.test.js
+++ b/src/__tests__/Menu.test.js
@@ -10,6 +10,7 @@ test.each([false, true])(
 
     // menu is unmounted
     utils.expectButtonToBeExpanded(false);
+    utils.expectMenuContainerToBeInTheDocument(false);
     utils.expectMenuToBeInTheDocument(false);
     expect(queryByRole('menuitem')).not.toBeInTheDocument();
 
@@ -18,6 +19,7 @@ test.each([false, true])(
     utils.expectButtonToBeExpanded(true);
     utils.expectMenuToHaveState('opening', false);
     utils.expectMenuToBeOpen(true);
+    utils.expectMenuContainerToBeInTheDocument(true);
     expect(utils.queryMenu()).toHaveAttribute('aria-label', 'Open');
     await waitFor(() => utils.expectMenuToHaveFocus());
     const menuItems = queryAllByRole('menuitem');
@@ -54,18 +56,22 @@ test.each([false, true])(
   async (portal) => {
     utils.renderMenu({ portal, unmountOnClose: true });
     utils.expectMenuToBeInTheDocument(false);
+    utils.expectMenuContainerToBeInTheDocument(false);
 
     utils.clickMenuButton();
     utils.expectMenuToBeInTheDocument(true);
+    utils.expectMenuContainerToBeInTheDocument(true);
     await waitFor(() => utils.expectMenuToHaveFocus());
 
     act(() => queryByRole('button').focus());
     utils.expectMenuToBeInTheDocument(false);
+    utils.expectMenuContainerToBeInTheDocument(false);
   }
 );
 
 test('Menu is in the DOM before first opening when initialMounted is true', () => {
   utils.renderMenu({ initialMounted: true });
+  utils.expectMenuContainerToBeInTheDocument(true);
   utils.expectMenuToBeInTheDocument(true);
   utils.expectMenuToHaveState('closed', true);
 });
@@ -172,7 +178,7 @@ test('Additional props are forwarded to Menu', () => {
 
   const container = screen.getByTestId('container');
   expect(container).toHaveAttribute('id', 'menu-container');
-  expect(container).toHaveStyle({ color: 'blue', position: 'relative' });
+  expect(container).toHaveStyle({ color: 'blue', position: 'absolute' });
 
   const menu = utils.queryMenu();
   expect(menu).toHaveAttribute('aria-label', 'test');

--- a/src/__tests__/SSR.test.js
+++ b/src/__tests__/SSR.test.js
@@ -16,19 +16,19 @@ const getMenu = (props) => (
 describe('Server rendering', () => {
   test('portal is not provided', () => {
     expect(renderToString(getMenu())).toContain(
-      '</button><div class="szh-menu-container" style="position:relative"><ul role="menu"'
+      '</button><div class="szh-menu-container" style="position:absolute"><ul role="menu"'
     );
   });
 
   test('portal is true', () => {
     expect(renderToString(getMenu({ portal: true }))).toContain(
-      '</button><div class="szh-menu-container" style="position:relative"><ul role="menu"'
+      '</button><div class="szh-menu-container" style="position:absolute"><ul role="menu"'
     );
   });
 
   test('portal.target is null', () => {
     expect(renderToString(getMenu({ portal: { target: null } }))).toContain(
-      '</button><div class="szh-menu-container" style="position:relative"><ul role="menu"'
+      '</button><div class="szh-menu-container" style="position:absolute"><ul role="menu"'
     );
   });
 
@@ -36,5 +36,9 @@ describe('Server rendering', () => {
     expect(renderToString(getMenu({ portal: { stablePosition: true } }))).toContain(
       '</button></main>'
     );
+  });
+
+  test('initialMounted is false', () => {
+    expect(renderToString(getMenu({ initialMounted: false }))).toContain('</button></main>');
   });
 });

--- a/src/__tests__/utils.js
+++ b/src/__tests__/utils.js
@@ -23,6 +23,9 @@ export const expectMenuToHaveFocus = (options) =>
 export const expectMenuToBeInTheDocument = (truthy, options) =>
   expectToBe(queryMenu(options), truthy).toBeInTheDocument();
 
+export const expectMenuContainerToBeInTheDocument = (truthy) =>
+  expectToBe(document.querySelector('.szh-menu-container'), truthy).toBeInTheDocument();
+
 export const expectMenuToBeOpen = (truthy, options) => {
   const menu = queryMenu(options);
   expect(menu).toHaveClass(`szh-menu--state-${truthy ? 'open' : 'closed'}`);

--- a/src/components/Menu.js
+++ b/src/components/Menu.js
@@ -21,7 +21,15 @@ import {
 } from '../utils';
 
 export const Menu = forwardRef(function Menu(
-  { 'aria-label': ariaLabel, captureFocus: _, menuButton, instanceRef, onMenuChange, ...restProps },
+  {
+    'aria-label': ariaLabel,
+    captureFocus: _,
+    initialOpen: _1,
+    menuButton,
+    instanceRef,
+    onMenuChange,
+    ...restProps
+  },
   externalRef
 ) {
   const [stateProps, toggleMenu, openMenu] = useMenuStateAndFocus(restProps);

--- a/src/components/MenuContainer.js
+++ b/src/components/MenuContainer.js
@@ -1,0 +1,64 @@
+import { useMemo } from 'react';
+import { useBEM } from '../hooks';
+import {
+  menuContainerClass,
+  mergeProps,
+  safeCall,
+  getTransition,
+  CloseReason,
+  Keys
+} from '../utils';
+
+export const MenuContainer = ({
+  className,
+  containerRef,
+  containerProps,
+  children,
+  isOpen,
+  skipOpen,
+  theming,
+  transition,
+  onClose
+}) => {
+  const itemTransition = getTransition(transition, 'item');
+
+  const onKeyDown = ({ key }) => {
+    switch (key) {
+      case Keys.ESC:
+        safeCall(onClose, { key, reason: CloseReason.CANCEL });
+        break;
+    }
+  };
+
+  const onBlur = (e) => {
+    if (isOpen && !e.currentTarget.contains(e.relatedTarget || document.activeElement)) {
+      safeCall(onClose, { reason: CloseReason.BLUR });
+
+      // If a user clicks on the menu button when a menu is open, we need to close the menu.
+      // However, a blur event will be fired prior to the click event on menu button,
+      // which makes the menu first close and then open again.
+      // If this happen, e.relatedTarget is incorrectly set to null instead of the button in Safari and Firefox,
+      // and makes it difficult to determine whether onBlur is fired because of clicking on menu button.
+      // This is a workaround approach which sets a flag to skip a following click event.
+      if (skipOpen) {
+        skipOpen.current = true;
+        setTimeout(() => (skipOpen.current = false), 300);
+      }
+    }
+  };
+
+  return (
+    <div
+      {...mergeProps({ onKeyDown, onBlur }, containerProps)}
+      className={useBEM({
+        block: menuContainerClass,
+        modifiers: useMemo(() => ({ theme: theming, itemTransition }), [theming, itemTransition]),
+        className
+      })}
+      style={{ position: 'absolute', ...containerProps?.style }}
+      ref={containerRef}
+    >
+      {children}
+    </div>
+  );
+};

--- a/src/components/MenuList.js
+++ b/src/components/MenuList.js
@@ -1,5 +1,6 @@
 import { useState, useReducer, useEffect, useRef, useMemo, useCallback, useContext } from 'react';
 import { flushSync } from 'react-dom';
+import { MenuContainer } from './MenuContainer';
 import { useBEM, useCombinedRef, useLayoutEffect, useItems } from '../hooks';
 import { getPositionHelpers, positionMenu } from '../positionUtils';
 import {
@@ -32,6 +33,7 @@ export const MenuList = ({
   anchorPoint,
   anchorRef,
   containerRef,
+  containerProps,
   externalRef,
   parentScrollingRef,
   arrow,
@@ -126,17 +128,8 @@ export const MenuList = ({
 
   const handlePosition = useCallback(
     (noOverflowCheck) => {
-      if (!containerRef.current) {
-        if (process.env.NODE_ENV !== 'production') {
-          console.error(
-            '[React-Menu] Menu cannot be positioned properly as container ref is null. If you need to initialise `state` prop to "open" for ControlledMenu, please see this solution: https://codesandbox.io/s/initial-open-sp10wn'
-          );
-        }
-        return;
-      }
-
       const anchorRect = anchorRef
-        ? anchorRef.current.getBoundingClientRect()
+        ? anchorRef.current?.getBoundingClientRect()
         : anchorPoint
         ? {
             left: anchorPoint.x,
@@ -150,7 +143,7 @@ export const MenuList = ({
       if (!anchorRect) {
         if (process.env.NODE_ENV !== 'production') {
           console.warn(
-            '[React-Menu] Menu might not be positioned properly as one of the anchorRef and anchorPoint prop should be provided.'
+            '[React-Menu] Menu might not be positioned properly as one of the anchorRef or anchorPoint prop should be provided. If `anchorRef` is provided, the anchor must be mounted before menu is open.'
           );
         }
         return;
@@ -416,7 +409,7 @@ export const MenuList = ({
     className: arrowClassName
   });
 
-  return (
+  const menu = (
     <ul
       role="menu"
       aria-label={ariaLabel}
@@ -454,5 +447,13 @@ export const MenuList = ({
         </MenuListItemContext.Provider>
       </MenuListContext.Provider>
     </ul>
+  );
+
+  return containerProps ? (
+    <MenuContainer {...containerProps} isOpen={isOpen}>
+      {menu}
+    </MenuContainer>
+  ) : (
+    menu
   );
 };

--- a/src/hooks/useMenuState.js
+++ b/src/hooks/useMenuState.js
@@ -2,12 +2,14 @@ import { useTransition } from 'react-transition-state';
 import { MenuStateMap, getTransition } from '../utils';
 
 export const useMenuState = ({
+  initialOpen,
   initialMounted,
   unmountOnClose,
   transition,
   transitionTimeout = 500
 } = {}) => {
   const [state, toggleMenu, endTransition] = useTransition({
+    initialEntered: initialOpen,
     mountOnEnter: !initialMounted,
     unmountOnExit: unmountOnClose,
     timeout: transitionTimeout,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -125,6 +125,10 @@ export type MenuArrowModifiers = Readonly<{
 
 export interface MenuStateOptions {
   /**
+   * Enable menu to be mounted in the open state.
+   */
+  initialOpen?: boolean;
+  /**
    * By default menu isn't mounted into DOM until it's opened for the first time.
    * Setting the prop to `true` will change this behaviour,
    * which also enables menu and its items to be server rendered.
@@ -246,7 +250,7 @@ interface BaseMenuProps extends Omit<BaseProps, 'style'> {
 /**
  * Common props for `Menu` and `ControlledMenu`
  */
-interface RootMenuProps extends BaseMenuProps, MenuStateOptions {
+interface RootMenuProps extends BaseMenuProps, Omit<MenuStateOptions, 'initialOpen'> {
   /**
    * Properties of this object are spread to the root DOM element containing the menu.
    */


### PR DESCRIPTION
- Prevent menu container from rendering into DOM before menu is open.
- Add `initialOpen` option to `useMenuState` hook.