### PR TITLE
fix: improve submenu experience

### DIFF
--- a/dist/es/components/ControlledMenu.js
+++ b/dist/es/components/ControlledMenu.js
@@ -4,7 +4,7 @@ import { createPortal } from 'react-dom';
 import { oneOf, exact, number, object, bool, oneOfType, string, func } from 'prop-types';
 import { MenuList } from './MenuList.js';
 import { jsx } from 'react/jsx-runtime';
-import { SettingsContext, ItemSettingsContext, EventHandlersContext, MenuStateMap, Keys, CloseReason } from '../utils/constants.js';
+import { SettingsContext, EventHandlersContext, MenuStateMap, Keys, CloseReason } from '../utils/constants.js';
 import { rootMenuPropTypes } from '../utils/propTypes.js';
 import { safeCall, values } from '../utils/utils.js';
 
@@ -49,15 +49,11 @@ var ControlledMenu = /*#__PURE__*/forwardRef(function ControlledMenu(_ref, exter
       rootAnchorRef: anchorRef,
       scrollNodesRef: scrollNodesRef,
       reposition: reposition,
-      viewScroll: viewScroll
-    };
-  }, [initialMounted, unmountOnClose, transition, transitionTimeout, anchorRef, boundingBoxRef, boundingBoxPadding, reposition, viewScroll]);
-  var itemSettings = useMemo(function () {
-    return {
+      viewScroll: viewScroll,
       submenuOpenDelay: submenuOpenDelay,
       submenuCloseDelay: submenuCloseDelay
     };
-  }, [submenuOpenDelay, submenuCloseDelay]);
+  }, [initialMounted, unmountOnClose, transition, transitionTimeout, anchorRef, boundingBoxRef, boundingBoxPadding, reposition, viewScroll, submenuOpenDelay, submenuCloseDelay]);
   var eventHandlers = useMemo(function () {
     return {
       handleClick: function handleClick(event, isCheckorRadio) {
@@ -85,25 +81,22 @@ var ControlledMenu = /*#__PURE__*/forwardRef(function ControlledMenu(_ref, exter
   if (!state) return null;
   var menuList = /*#__PURE__*/jsx(SettingsContext.Provider, {
     value: settings,
-    children: /*#__PURE__*/jsx(ItemSettingsContext.Provider, {
-      value: itemSettings,
-      children: /*#__PURE__*/jsx(EventHandlersContext.Provider, {
-        value: eventHandlers,
-        children: /*#__PURE__*/jsx(MenuList, _extends({}, restProps, {
-          ariaLabel: ariaLabel || 'Menu',
-          externalRef: externalRef,
+    children: /*#__PURE__*/jsx(EventHandlersContext.Provider, {
+      value: eventHandlers,
+      children: /*#__PURE__*/jsx(MenuList, _extends({}, restProps, {
+        ariaLabel: ariaLabel || 'Menu',
+        externalRef: externalRef,
+        containerRef: containerRef,
+        containerProps: {
+          className: className,
           containerRef: containerRef,
-          containerProps: {
-            className: className,
-            containerRef: containerRef,
-            containerProps: containerProps,
-            skipOpen: skipOpen,
-            theming: theming,
-            transition: transition,
-            onClose: onClose
-          }
-        }))
-      })
+          containerProps: containerProps,
+          skipOpen: skipOpen,
+          theming: theming,
+          transition: transition,
+          onClose: onClose
+        }
+      }))
     })
   });
   if (portal === true && typeof document !== 'undefined') {

--- a/dist/es/components/FocusableItem.js
+++ b/dist/es/components/FocusableItem.js
@@ -2,10 +2,10 @@ import { extends as _extends, objectWithoutPropertiesLoose as _objectWithoutProp
 import { useRef, useContext, useMemo } from 'react';
 import { bool, func } from 'prop-types';
 import { jsx } from 'react/jsx-runtime';
-import { withHovering } from '../utils/withHovering.js';
 import { useItemState } from '../hooks/useItemState.js';
 import { useCombinedRef } from '../hooks/useCombinedRef.js';
 import { useBEM } from '../hooks/useBEM.js';
+import { withHovering } from '../utils/withHovering.js';
 import { stylePropTypes } from '../utils/propTypes.js';
 import { EventHandlersContext, roleMenuitem, menuClass, menuItemClass } from '../utils/constants.js';
 import { safeCall, mergeProps, commonProps } from '../utils/utils.js';

--- a/dist/es/components/MenuItem.js
+++ b/dist/es/components/MenuItem.js
@@ -2,11 +2,11 @@ import { extends as _extends, objectWithoutPropertiesLoose as _objectWithoutProp
 import { useContext, useMemo } from 'react';
 import { any, string, oneOf, bool, oneOfType, node, func } from 'prop-types';
 import { jsx } from 'react/jsx-runtime';
-import { withHovering } from '../utils/withHovering.js';
 import { useItemState } from '../hooks/useItemState.js';
 import { EventHandlersContext, RadioGroupContext, roleMenuitem, menuClass, menuItemClass, roleNone, Keys } from '../utils/constants.js';
 import { useCombinedRef } from '../hooks/useCombinedRef.js';
 import { useBEM } from '../hooks/useBEM.js';
+import { withHovering } from '../utils/withHovering.js';
 import { stylePropTypes } from '../utils/propTypes.js';
 import { mergeProps, commonProps, safeCall } from '../utils/utils.js';
 

--- a/dist/es/utils/constants.js
+++ b/dist/es/utils/constants.js
@@ -16,7 +16,6 @@ var MenuListContext = /*#__PURE__*/createContext({});
 var EventHandlersContext = /*#__PURE__*/createContext({});
 var RadioGroupContext = /*#__PURE__*/createContext({});
 var SettingsContext = /*#__PURE__*/createContext({});
-var ItemSettingsContext = /*#__PURE__*/createContext({});
 var Keys = /*#__PURE__*/Object.freeze({
   ENTER: 'Enter',
   ESC: 'Escape',
@@ -62,4 +61,4 @@ var dummyItemProps = {
   role: roleMenuitem
 };
 
-export { CloseReason, EventHandlersContext, FocusPositions, HoverActionTypes, HoverItemContext, ItemSettingsContext, Keys, MenuListContext, MenuListItemContext, MenuStateMap, RadioGroupContext, SettingsContext, dummyItemProps, menuArrowClass, menuButtonClass, menuClass, menuContainerClass, menuDividerClass, menuGroupClass, menuHeaderClass, menuItemClass, positionAbsolute, radioGroupClass, roleMenuitem, roleNone, subMenuClass };
+export { CloseReason, EventHandlersContext, FocusPositions, HoverActionTypes, HoverItemContext, Keys, MenuListContext, MenuListItemContext, MenuStateMap, RadioGroupContext, SettingsContext, dummyItemProps, menuArrowClass, menuButtonClass, menuClass, menuContainerClass, menuDividerClass, menuGroupClass, menuHeaderClass, menuItemClass, positionAbsolute, radioGroupClass, roleMenuitem, roleNone, subMenuClass };

--- a/dist/es/utils/submenuCtx.js
+++ b/dist/es/utils/submenuCtx.js
@@ -1,0 +1,28 @@
+var createSubmenuCtx = function createSubmenuCtx() {
+  var timer,
+    count = 0;
+  return {
+    toggle: function toggle(isOpen) {
+      isOpen ? count++ : count--;
+      count = Math.max(count, 0);
+    },
+    on: function on(closeDelay, pending, settled) {
+      if (count) {
+        if (!timer) timer = setTimeout(function () {
+          timer = 0;
+          pending();
+        }, closeDelay);
+      } else {
+        settled == null ? void 0 : settled();
+      }
+    },
+    off: function off() {
+      if (timer) {
+        clearTimeout(timer);
+        timer = 0;
+      }
+    }
+  };
+};
+
+export { createSubmenuCtx };

--- a/dist/es/utils/utils.js
+++ b/dist/es/utils/utils.js
@@ -67,7 +67,7 @@ var parsePadding = function parsePadding(paddingStr) {
 var getScrollAncestor = function getScrollAncestor(node) {
   while (node) {
     node = node.parentNode;
-    if (!node || node === document.body) return;
+    if (!node || node === document.body || !node.parentNode) return;
     var _getComputedStyle = getComputedStyle(node),
       overflow = _getComputedStyle.overflow,
       overflowX = _getComputedStyle.overflowX,

--- a/dist/index.js
+++ b/dist/index.js
@@ -245,7 +245,7 @@ var parsePadding = function parsePadding(paddingStr) {
 var getScrollAncestor = function getScrollAncestor(node) {
   while (node) {
     node = node.parentNode;
-    if (!node || node === document.body) return;
+    if (!node || node === document.body || !node.parentNode) return;
     var _getComputedStyle = getComputedStyle(node),
       overflow = _getComputedStyle.overflow,
       overflowX = _getComputedStyle.overflowX,

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -3313,6 +3313,66 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@next/swc-android-arm-eabi": {
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-13.2.4.tgz",
+      "integrity": "sha512-DWlalTSkLjDU11MY11jg17O1gGQzpRccM9Oes2yTqj2DpHndajrXHGxj9HGtJ+idq2k7ImUdJVWS2h2l/EDJOw==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-android-arm64": {
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-13.2.4.tgz",
+      "integrity": "sha512-sRavmUImUCf332Gy+PjIfLkMhiRX1Ez4SI+3vFDRs1N5eXp+uNzjFUK/oLMMOzk6KFSkbiK/3Wt8+dHQR/flNg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-freebsd-x64": {
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-13.2.4.tgz",
+      "integrity": "sha512-kkbzKVZGPaXRBPisoAQkh3xh22r+TD+5HwoC5bOkALraJ0dsOQgSMAvzMXKsN3tMzJUPS0tjtRf1cTzrQ0I5vQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm-gnueabihf": {
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-13.2.4.tgz",
+      "integrity": "sha512-7qA1++UY0fjprqtjBZaOA6cas/7GekpjVsZn/0uHvquuITFCdKGFCsKNBx3S0Rpxmx6WYo0GcmhNRM9ru08BGg==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
     }
   },
   "dependencies": {
@@ -5642,6 +5702,30 @@
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true,
       "peer": true
+    },
+    "@next/swc-android-arm-eabi": {
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-13.2.4.tgz",
+      "integrity": "sha512-DWlalTSkLjDU11MY11jg17O1gGQzpRccM9Oes2yTqj2DpHndajrXHGxj9HGtJ+idq2k7ImUdJVWS2h2l/EDJOw==",
+      "optional": true
+    },
+    "@next/swc-android-arm64": {
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-13.2.4.tgz",
+      "integrity": "sha512-sRavmUImUCf332Gy+PjIfLkMhiRX1Ez4SI+3vFDRs1N5eXp+uNzjFUK/oLMMOzk6KFSkbiK/3Wt8+dHQR/flNg==",
+      "optional": true
+    },
+    "@next/swc-freebsd-x64": {
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-13.2.4.tgz",
+      "integrity": "sha512-kkbzKVZGPaXRBPisoAQkh3xh22r+TD+5HwoC5bOkALraJ0dsOQgSMAvzMXKsN3tMzJUPS0tjtRf1cTzrQ0I5vQ==",
+      "optional": true
+    },
+    "@next/swc-linux-arm-gnueabihf": {
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-13.2.4.tgz",
+      "integrity": "sha512-7qA1++UY0fjprqtjBZaOA6cas/7GekpjVsZn/0uHvquuITFCdKGFCsKNBx3S0Rpxmx6WYo0GcmhNRM9ru08BGg==",
+      "optional": true
     }
   }
 }

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -21,26 +21,26 @@
     },
     "..": {
       "name": "@szhsin/react-menu",
-      "version": "3.5.2",
+      "version": "3.5.3",
       "license": "MIT",
       "dependencies": {
         "prop-types": "^15.7.2",
         "react-transition-state": "^1.1.5"
       },
       "devDependencies": {
-        "@babel/core": "^7.21.3",
-        "@babel/preset-env": "^7.20.2",
+        "@babel/core": "^7.21.4",
+        "@babel/preset-env": "^7.21.4",
         "@babel/preset-react": "^7.18.6",
         "@rollup/plugin-babel": "^6.0.3",
-        "@rollup/plugin-node-resolve": "^15.0.1",
+        "@rollup/plugin-node-resolve": "^15.0.2",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
-        "@types/jest": "^29.5.0",
-        "@types/react": "^18.0.31",
+        "@types/jest": "^29.5.1",
+        "@types/react": "^18.0.37",
         "babel-plugin-pure-annotations": "^0.1.2",
         "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
         "dtslint": "^4.2.1",
-        "eslint": "^8.37.0",
+        "eslint": "^8.38.0",
         "eslint-config-prettier": "^8.8.0",
         "eslint-plugin-jest": "^27.2.1",
         "eslint-plugin-react": "^7.32.2",
@@ -52,8 +52,8 @@
         "prettier": "^2.8.7",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "rollup": "^3.20.2",
-        "sass": "^1.60.0",
+        "rollup": "^3.20.6",
+        "sass": "^1.62.0",
         "typescript": "^4.9.5"
       },
       "peerDependencies": {
@@ -3313,66 +3313,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/@next/swc-android-arm-eabi": {
-      "version": "13.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-13.2.4.tgz",
-      "integrity": "sha512-DWlalTSkLjDU11MY11jg17O1gGQzpRccM9Oes2yTqj2DpHndajrXHGxj9HGtJ+idq2k7ImUdJVWS2h2l/EDJOw==",
-      "cpu": [
-        "arm"
-      ],
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-android-arm64": {
-      "version": "13.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-13.2.4.tgz",
-      "integrity": "sha512-sRavmUImUCf332Gy+PjIfLkMhiRX1Ez4SI+3vFDRs1N5eXp+uNzjFUK/oLMMOzk6KFSkbiK/3Wt8+dHQR/flNg==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-freebsd-x64": {
-      "version": "13.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-13.2.4.tgz",
-      "integrity": "sha512-kkbzKVZGPaXRBPisoAQkh3xh22r+TD+5HwoC5bOkALraJ0dsOQgSMAvzMXKsN3tMzJUPS0tjtRf1cTzrQ0I5vQ==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-arm-gnueabihf": {
-      "version": "13.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-13.2.4.tgz",
-      "integrity": "sha512-7qA1++UY0fjprqtjBZaOA6cas/7GekpjVsZn/0uHvquuITFCdKGFCsKNBx3S0Rpxmx6WYo0GcmhNRM9ru08BGg==",
-      "cpu": [
-        "arm"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
     }
   },
   "dependencies": {
@@ -3564,19 +3504,19 @@
     "@szhsin/react-menu": {
       "version": "file:..",
       "requires": {
-        "@babel/core": "^7.21.3",
-        "@babel/preset-env": "^7.20.2",
+        "@babel/core": "^7.21.4",
+        "@babel/preset-env": "^7.21.4",
         "@babel/preset-react": "^7.18.6",
         "@rollup/plugin-babel": "^6.0.3",
-        "@rollup/plugin-node-resolve": "^15.0.1",
+        "@rollup/plugin-node-resolve": "^15.0.2",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
-        "@types/jest": "^29.5.0",
-        "@types/react": "^18.0.31",
+        "@types/jest": "^29.5.1",
+        "@types/react": "^18.0.37",
         "babel-plugin-pure-annotations": "^0.1.2",
         "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
         "dtslint": "^4.2.1",
-        "eslint": "^8.37.0",
+        "eslint": "^8.38.0",
         "eslint-config-prettier": "^8.8.0",
         "eslint-plugin-jest": "^27.2.1",
         "eslint-plugin-react": "^7.32.2",
@@ -3590,8 +3530,8 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-transition-state": "^1.1.5",
-        "rollup": "^3.20.2",
-        "sass": "^1.60.0",
+        "rollup": "^3.20.6",
+        "sass": "^1.62.0",
         "typescript": "^4.9.5"
       },
       "dependencies": {
@@ -5702,30 +5642,6 @@
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true,
       "peer": true
-    },
-    "@next/swc-android-arm-eabi": {
-      "version": "13.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-13.2.4.tgz",
-      "integrity": "sha512-DWlalTSkLjDU11MY11jg17O1gGQzpRccM9Oes2yTqj2DpHndajrXHGxj9HGtJ+idq2k7ImUdJVWS2h2l/EDJOw==",
-      "optional": true
-    },
-    "@next/swc-android-arm64": {
-      "version": "13.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-13.2.4.tgz",
-      "integrity": "sha512-sRavmUImUCf332Gy+PjIfLkMhiRX1Ez4SI+3vFDRs1N5eXp+uNzjFUK/oLMMOzk6KFSkbiK/3Wt8+dHQR/flNg==",
-      "optional": true
-    },
-    "@next/swc-freebsd-x64": {
-      "version": "13.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-13.2.4.tgz",
-      "integrity": "sha512-kkbzKVZGPaXRBPisoAQkh3xh22r+TD+5HwoC5bOkALraJ0dsOQgSMAvzMXKsN3tMzJUPS0tjtRf1cTzrQ0I5vQ==",
-      "optional": true
-    },
-    "@next/swc-linux-arm-gnueabihf": {
-      "version": "13.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-13.2.4.tgz",
-      "integrity": "sha512-7qA1++UY0fjprqtjBZaOA6cas/7GekpjVsZn/0uHvquuITFCdKGFCsKNBx3S0Rpxmx6WYo0GcmhNRM9ru08BGg==",
-      "optional": true
     }
   }
 }

--- a/example/src/utils/index.js
+++ b/example/src/utils/index.js
@@ -1,8 +1,8 @@
 import { useEffect, useLayoutEffect } from 'react';
 import { useTheme } from '../store';
 
-export const version = '3.5.2';
-export const build = '129';
+export const version = '3.5.3';
+export const build = '130';
 
 export const bem = (block, element, modifiers = {}) => {
   let blockElement = element ? `${block}__${element}` : block;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@szhsin/react-menu",
-  "version": "3.5.2",
+  "version": "3.5.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@szhsin/react-menu",
-      "version": "3.5.2",
+      "version": "3.5.3",
       "license": "MIT",
       "dependencies": {
         "prop-types": "^15.7.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1812,12 +1812,12 @@
       "dev": true
     },
     "node_modules/@definitelytyped/utils": {
-      "version": "0.0.121",
-      "resolved": "https://registry.npmjs.org/@definitelytyped/utils/-/utils-0.0.121.tgz",
-      "integrity": "sha512-H2g09ZJcmCk0BAy86M/UcMP4pq0UGaKBGpjPjPe5btKgZDB6A1Tn1/TKd46cQ6grhFdsxJFE5cb8XWGTKkpA8w==",
+      "version": "0.0.159",
+      "resolved": "https://registry.npmjs.org/@definitelytyped/utils/-/utils-0.0.159.tgz",
+      "integrity": "sha512-zm+Gsw39sD2EANlJmmNXgtpIzXO3QmBq5nZx6Y95RD/s2AypDaBw0eauO1wWji6I45tJOAgPZEvfmjjaxfoyhA==",
       "dev": true,
       "dependencies": {
-        "@definitelytyped/typescript-versions": "^0.0.121",
+        "@definitelytyped/typescript-versions": "^0.0.159",
         "@qiwi/npm-registry-client": "^8.9.1",
         "@types/node": "^14.14.35",
         "charm": "^1.0.2",
@@ -1828,9 +1828,9 @@
       }
     },
     "node_modules/@definitelytyped/utils/node_modules/@definitelytyped/typescript-versions": {
-      "version": "0.0.121",
-      "resolved": "https://registry.npmjs.org/@definitelytyped/typescript-versions/-/typescript-versions-0.0.121.tgz",
-      "integrity": "sha512-mTfkR7MrGo08lzOPZx3ZgIER9PoalRZok3hmrsLDxTUhS5lrgdgXBOpAyDMtnJUAO6AxrIx126XGlkN+1rvKcA==",
+      "version": "0.0.159",
+      "resolved": "https://registry.npmjs.org/@definitelytyped/typescript-versions/-/typescript-versions-0.0.159.tgz",
+      "integrity": "sha512-9TWRPpOo3CWYUyS3QCu8goJbAhS3qAE/LWFc+Qy6Wb8vsUAwMTioCtPPsYyqrPDbatXvPFrOr182hE1OFvEFSA==",
       "dev": true
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -4251,9 +4251,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001407",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001407.tgz",
-      "integrity": "sha512-4ydV+t4P7X3zH83fQWNDX/mQEzYomossfpViCOx9zHBSMV+rIe3LFqglHHtVyvNl1FhTNxPxs3jei82iqOW04w==",
+      "version": "1.0.30001481",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001481.tgz",
+      "integrity": "sha512-KCqHwRnaa1InZBtqXzP98LPg0ajCVujMKjqKDhZEthIpAsJl/YEIa3YvXjGXPVqzZVguccuu7ga9KOE1J9rKPQ==",
       "dev": true,
       "funding": [
         {
@@ -4263,6 +4263,10 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ]
     },
@@ -13011,12 +13015,12 @@
       "dev": true
     },
     "@definitelytyped/utils": {
-      "version": "0.0.121",
-      "resolved": "https://registry.npmjs.org/@definitelytyped/utils/-/utils-0.0.121.tgz",
-      "integrity": "sha512-H2g09ZJcmCk0BAy86M/UcMP4pq0UGaKBGpjPjPe5btKgZDB6A1Tn1/TKd46cQ6grhFdsxJFE5cb8XWGTKkpA8w==",
+      "version": "0.0.159",
+      "resolved": "https://registry.npmjs.org/@definitelytyped/utils/-/utils-0.0.159.tgz",
+      "integrity": "sha512-zm+Gsw39sD2EANlJmmNXgtpIzXO3QmBq5nZx6Y95RD/s2AypDaBw0eauO1wWji6I45tJOAgPZEvfmjjaxfoyhA==",
       "dev": true,
       "requires": {
-        "@definitelytyped/typescript-versions": "^0.0.121",
+        "@definitelytyped/typescript-versions": "^0.0.159",
         "@qiwi/npm-registry-client": "^8.9.1",
         "@types/node": "^14.14.35",
         "charm": "^1.0.2",
@@ -13027,9 +13031,9 @@
       },
       "dependencies": {
         "@definitelytyped/typescript-versions": {
-          "version": "0.0.121",
-          "resolved": "https://registry.npmjs.org/@definitelytyped/typescript-versions/-/typescript-versions-0.0.121.tgz",
-          "integrity": "sha512-mTfkR7MrGo08lzOPZx3ZgIER9PoalRZok3hmrsLDxTUhS5lrgdgXBOpAyDMtnJUAO6AxrIx126XGlkN+1rvKcA==",
+          "version": "0.0.159",
+          "resolved": "https://registry.npmjs.org/@definitelytyped/typescript-versions/-/typescript-versions-0.0.159.tgz",
+          "integrity": "sha512-9TWRPpOo3CWYUyS3QCu8goJbAhS3qAE/LWFc+Qy6Wb8vsUAwMTioCtPPsYyqrPDbatXvPFrOr182hE1OFvEFSA==",
           "dev": true
         }
       }
@@ -14874,9 +14878,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001407",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001407.tgz",
-      "integrity": "sha512-4ydV+t4P7X3zH83fQWNDX/mQEzYomossfpViCOx9zHBSMV+rIe3LFqglHHtVyvNl1FhTNxPxs3jei82iqOW04w==",
+      "version": "1.0.30001481",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001481.tgz",
+      "integrity": "sha512-KCqHwRnaa1InZBtqXzP98LPg0ajCVujMKjqKDhZEthIpAsJl/YEIa3YvXjGXPVqzZVguccuu7ga9KOE1J9rKPQ==",
       "dev": true
     },
     "caseless": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@szhsin/react-menu",
-  "version": "3.5.2",
+  "version": "3.5.3",
   "description": "React component for building accessible menu, dropdown, submenu, context menu and more.",
   "author": "Zheng Song",
   "license": "MIT",

--- a/src/__tests__/Menu.test.js
+++ b/src/__tests__/Menu.test.js
@@ -158,20 +158,20 @@ test('Navigate with arrow keys', async () => {
 });
 
 test('Additional props are forwarded to Menu', () => {
-  const onPointerMove = jest.fn();
+  const onPointerEnter = jest.fn();
   const onKeyDown = jest.fn();
   utils.renderMenu({
     ['aria-label']: 'test',
     ['aria-haspopup']: true,
     randomattr: 'random',
     tabIndex: undefined,
-    onPointerMove,
+    onPointerEnter,
     onKeyDown,
     containerProps: {
       'data-testid': 'container',
       id: 'menu-container',
       style: { color: 'blue' },
-      onPointerMove,
+      onPointerEnter,
       onKeyDown
     },
     focusProps: {
@@ -194,8 +194,8 @@ test('Additional props are forwarded to Menu', () => {
   expect(menu).toHaveAttribute('aria-haspopup', 'true');
   expect(menu).toHaveAttribute('randomattr', 'random');
   expect(menu).not.toHaveAttribute('tabindex');
-  fireEvent.pointerMove(menu);
-  expect(onPointerMove).toHaveBeenCalledTimes(2);
+  fireEvent.pointerEnter(menu);
+  expect(onPointerEnter).toHaveBeenCalledTimes(2);
   fireEvent.keyDown(menu, { key: 'm' });
   expect(onKeyDown).toHaveBeenCalledTimes(2);
   expect(onKeyDown).toHaveBeenLastCalledWith(expect.objectContaining({ key: 'm' }));

--- a/src/components/ControlledMenu.js
+++ b/src/components/ControlledMenu.js
@@ -10,8 +10,7 @@ import {
   Keys,
   MenuStateMap,
   EventHandlersContext,
-  SettingsContext,
-  ItemSettingsContext
+  SettingsContext
 } from '../utils';
 
 export const ControlledMenu = forwardRef(function ControlledMenu(
@@ -53,7 +52,9 @@ export const ControlledMenu = forwardRef(function ControlledMenu(
       rootAnchorRef: anchorRef,
       scrollNodesRef,
       reposition,
-      viewScroll
+      viewScroll,
+      submenuOpenDelay,
+      submenuCloseDelay
     }),
     [
       initialMounted,
@@ -64,16 +65,10 @@ export const ControlledMenu = forwardRef(function ControlledMenu(
       boundingBoxRef,
       boundingBoxPadding,
       reposition,
-      viewScroll
-    ]
-  );
-
-  const itemSettings = useMemo(
-    () => ({
+      viewScroll,
       submenuOpenDelay,
       submenuCloseDelay
-    }),
-    [submenuOpenDelay, submenuCloseDelay]
+    ]
   );
 
   const eventHandlers = useMemo(
@@ -109,25 +104,23 @@ export const ControlledMenu = forwardRef(function ControlledMenu(
 
   const menuList = (
     <SettingsContext.Provider value={settings}>
-      <ItemSettingsContext.Provider value={itemSettings}>
-        <EventHandlersContext.Provider value={eventHandlers}>
-          <MenuList
-            {...restProps}
-            ariaLabel={ariaLabel || 'Menu'}
-            externalRef={externalRef}
-            containerRef={containerRef}
-            containerProps={{
-              className,
-              containerRef,
-              containerProps,
-              skipOpen,
-              theming,
-              transition,
-              onClose
-            }}
-          />
-        </EventHandlersContext.Provider>
-      </ItemSettingsContext.Provider>
+      <EventHandlersContext.Provider value={eventHandlers}>
+        <MenuList
+          {...restProps}
+          ariaLabel={ariaLabel || 'Menu'}
+          externalRef={externalRef}
+          containerRef={containerRef}
+          containerProps={{
+            className,
+            containerRef,
+            containerProps,
+            skipOpen,
+            theming,
+            transition,
+            onClose
+          }}
+        />
+      </EventHandlersContext.Provider>
     </SettingsContext.Provider>
   );
 

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -17,7 +17,6 @@ export const MenuListContext = createContext({});
 export const EventHandlersContext = createContext({});
 export const RadioGroupContext = createContext({});
 export const SettingsContext = createContext({});
-export const ItemSettingsContext = createContext({});
 
 export const Keys = Object.freeze({
   ENTER: 'Enter',

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,4 +1,5 @@
 export * from './constants';
 export * from './utils';
 export * from './propTypes';
-export { withHovering } from './withHovering';
+export * from './submenuCtx';
+export * from './withHovering';

--- a/src/utils/submenuCtx.js
+++ b/src/utils/submenuCtx.js
@@ -1,0 +1,29 @@
+const createSubmenuCtx = () => {
+  let timer,
+    count = 0;
+  return {
+    toggle: (isOpen) => {
+      isOpen ? count++ : count--;
+      count = Math.max(count, 0);
+    },
+    on: (closeDelay, pending, settled) => {
+      if (count) {
+        if (!timer)
+          timer = setTimeout(() => {
+            timer = 0;
+            pending();
+          }, closeDelay);
+      } else {
+        settled?.();
+      }
+    },
+    off: () => {
+      if (timer) {
+        clearTimeout(timer);
+        timer = 0;
+      }
+    }
+  };
+};
+
+export { createSubmenuCtx };


### PR DESCRIPTION
This PR is to improve submenu experience by attempting to align the behaviour with native OS menus. Once merged, it should:
- Resolve the issue #903
- Close a submenu when mouse moves over any real estate within an ancestor menu.
- When mouse moves from a submenu anchor item towards a submenu, and if the mouse has moved across space within the parent menu, the submenu should stay open.