### PR TITLE
Typescript: support download prop

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -530,6 +530,7 @@ export interface MenuItemProps extends Omit<BaseProps<MenuItemModifiers>, 'onCli
   href?: string;
   rel?: string;
   target?: string;
+  download?: string;
   /**
    * Set this prop to make the item a checkbox or radio menu item.
    */


### PR DESCRIPTION
The [`download` prop of the `<a>` tag](https://developer.mozilla.org/en-US/docs/Web/API/HTMLAnchorElement/download) allows web developers to indicate that a link (`<a>` tag) is intended to be downloaded as a file, rather than viewed in the browser. It's already possible to pass this prop to the `<MenuItem>` component; this change just tells Typescript that this is an expected/supported property.