### PR TITLE
Fix documentation about using any button

### DIFF
--- a/example/src/data/codeExamples.js
+++ b/example/src/data/codeExamples.js
@@ -640,8 +640,8 @@ export const customisedButton = {
     <>
       <p>
         You can use a native button element with <code>Menu</code>, or use your own React button
-        component which implements a forwarding ref and accepts <code>onClick</code> and{' '}
-        <code>onKeyDown</code> event props.
+        component which implements a forwarding ref and accepts <code>onClick</code>,{' '}
+        <code>onKeyDown</code> and <code>onMouseDown</code> event props.
       </p>
       <p>
         <code>Menu</code> also works well with popular React libraries, such as the{' '}


### PR DESCRIPTION
When using my own button on an uncontrolled `Menu` component, clicking the button once while the menu was open was closing then re-opening the menu. (Similar to https://github.com/szhsin/react-menu/issues/838)

The issue was that my own button was accepting the `onClick` and `onKeyDown` props, as documented here: https://szhsin.github.io/react-menu#customised-btn

However, `onMouseDown` must also be passed to the button as found here: https://github.com/szhsin/react-menu/blob/dd5a8d9088c5115234573bd5dc1ddf0df564d81e/src/components/Menu.js#L67 and https://github.com/szhsin/react-menu/blob/dd5a8d9088c5115234573bd5dc1ddf0df564d81e/src/hooks/useClick.js#L10

This PR updates the documentation to reflect that.