### PR TITLE
fix: skip repositioning for zero-size observer elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![NPM](https://img.shields.io/npm/v/@szhsin/react-menu.svg)](https://www.npmjs.com/package/@szhsin/react-menu)
 [![NPM](https://img.shields.io/npm/dm/@szhsin/react-menu)](https://www.npmjs.com/package/@szhsin/react-menu)
 [![bundlephobia](https://img.shields.io/bundlephobia/minzip/@szhsin/react-menu)](https://bundlephobia.com/package/@szhsin/react-menu)
-[![Known Vulnerabilities](https://snyk.io/test/github/szhsin/react-menu/badge.svg)](https://snyk.io/test/github/szhsin/react-menu)
+[![Snyk Vulnerability Badge](https://snyk.io/test/github/szhsin/react-menu/badge.svg)](https://snyk.io/test/github/szhsin/react-menu)
 
 ## Features
 

--- a/dist/cjs/components/MenuList.cjs
+++ b/dist/cjs/components/MenuList.cjs
@@ -257,7 +257,7 @@ const MenuList = ({
     }) => {
       if (targetList.indexOf(target) < 0) {
         targetList.push(target);
-      } else {
+      } else if (target.offsetWidth && target.offsetHeight) {
         reactDom.flushSync(() => {
           handlePosition();
           forceReposSubmenu();

--- a/dist/esm/components/MenuList.mjs
+++ b/dist/esm/components/MenuList.mjs
@@ -255,7 +255,7 @@ const MenuList = ({
     }) => {
       if (targetList.indexOf(target) < 0) {
         targetList.push(target);
-      } else {
+      } else if (target.offsetWidth && target.offsetHeight) {
         flushSync(() => {
           handlePosition();
           forceReposSubmenu();

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -21,7 +21,7 @@
     },
     "..": {
       "name": "@szhsin/react-menu",
-      "version": "4.5.1",
+      "version": "4.5.2",
       "license": "MIT",
       "dependencies": {
         "react-transition-state": "^2.4.0"
@@ -30,6 +30,7 @@
         "@babel/core": "^7.29.7",
         "@babel/preset-env": "^7.29.7",
         "@babel/preset-react": "^7.29.7",
+        "@eslint/js": "^10.0.1",
         "@rollup/plugin-babel": "^7.1.0",
         "@rollup/plugin-node-resolve": "^16.0.3",
         "@testing-library/jest-dom": "^6.9.1",
@@ -43,7 +44,6 @@
         "eslint": "^10.4.1",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-jest": "^29.15.2",
-        "eslint-plugin-react": "^7.37.5",
         "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-react-hooks-addons": "^0.5.1",
         "globals": "^17.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@szhsin/react-menu",
-  "version": "4.5.1",
+  "version": "4.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@szhsin/react-menu",
-      "version": "4.5.1",
+      "version": "4.5.2",
       "license": "MIT",
       "dependencies": {
         "react-transition-state": "^2.4.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@szhsin/react-menu",
-  "version": "4.5.1",
+  "version": "4.5.2",
   "description": "React component for building accessible menu, dropdown, submenu, context menu, and more",
   "author": "Zheng Song",
   "license": "MIT",

--- a/src/components/MenuList.js
+++ b/src/components/MenuList.js
@@ -309,7 +309,7 @@ export const MenuList = ({
           // ResizeObserver callback fires on initial observe call,
           // use this workaround to skip the first callback
           targetList.push(target);
-        } else {
+        } else if (target.offsetWidth && target.offsetHeight) {
           flushSync(() => {
             handlePosition();
             forceReposSubmenu();


### PR DESCRIPTION
Fix submenu flicker when closing menus with overflow clipping. Skip repositioning when the observer element reports a zero size during menu teardown.